### PR TITLE
Fix no delete share memory

### DIFF
--- a/src/Fork.php
+++ b/src/Fork.php
@@ -82,6 +82,8 @@ class Fork
 
         # If no errors occured then we're done
         if ($error === 0) {
+            # For delete shared memory when use PcntlAdapter
+            $this->adapter->getExceptions();
             return;
         }
 


### PR DESCRIPTION
Missing call `shaop_delele()` when the closure function is done without any exceptions in PcntlAdapter.

```php
// For delete shared memory when use PcntlAdapter
$this->adapter->getExceptions();
```

