### PR TITLE
Fix no delete share memory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "duncan3dc/fork-helper",
+    "name": "eaglewu/fork-helper",
     "type": "library",
     "description": "Simple class to fork processes in PHP and allow multi-threading",
     "keywords": ["fork","process","control","pcntl","multi-threading"],
-    "homepage": "https://github.com/duncan3dc/fork-helper",
+    "homepage": "https://github.com/eaglewu/fork-helper",
     "license": "Apache-2.0",
     "authors": [{
         "name": "Craig Duncan",

--- a/src/Fork.php
+++ b/src/Fork.php
@@ -80,12 +80,12 @@ class Fork
             unset($this->threads[$pid]);
         }
 
+        $exceptions = $this->adapter->getExceptions();
+
         # If no errors occured then we're done
         if ($error === 0) {
             return;
         }
-
-        $exceptions = $this->adapter->getExceptions();
 
         $message = "An error occurred within a thread, the return code was: {$error}\n";
         foreach ($exceptions as $exception) {

--- a/src/SharedMemory.php
+++ b/src/SharedMemory.php
@@ -81,13 +81,17 @@ final class SharedMemory
      */
     public function getExceptions(): array
     {
-        $memory = shmop_open($this->key, "a", 0, 0);
+        try {
+            $memory = shmop_open($this->key, "a", 0, 0);
 
-        $exceptions = $this->unserialize($memory);
+            $exceptions = $this->unserialize($memory);
 
-        shmop_delete($memory);
-        shmop_close($memory);
+            shmop_delete($memory);
+            shmop_close($memory);
 
-        return $exceptions;
+            return $exceptions;
+        } catch (\Exception $e) {
+            return [];
+        }
     }
 }


### PR DESCRIPTION
Missing call `shaop_delele()` in `getExceptions`  when the closure function is done without any exceptions in PcntlAdapter.

