### PR TITLE
Fix warnings on SharedMemory::delete()

### DIFF
--- a/src/SharedMemory.php
+++ b/src/SharedMemory.php
@@ -115,8 +115,10 @@ final class SharedMemory
      */
     public function delete()
     {
-        $memory = shmop_open($this->key, "a", 0, 0);
-        shmop_delete($memory);
-        shmop_close($memory);
+        $memory = @shmop_open($this->key, "a", 0, 0);
+        if ($memory) {
+            shmop_delete($memory);
+            shmop_close($memory);
+        }
     }
 }


### PR DESCRIPTION
In case of shmop_open fails we shouldn't call shmop_delete and shmop_close and we shouldn't generate warning about shmop_open fails.