### PR TITLE
Automated native_function_invocation fixes

### DIFF
--- a/src/Fork.php
+++ b/src/Fork.php
@@ -28,7 +28,7 @@ class Fork implements ForkInterface
     public function __construct(AdapterInterface $adapter = null)
     {
         if ($adapter === null) {
-            if (function_exists("pcntl_fork")) {
+            if (\function_exists("pcntl_fork")) {
                 $adapter = new PcntlAdapter();
             } else {
                 $adapter = new SingleThreadAdapter();
@@ -57,7 +57,7 @@ class Fork implements ForkInterface
      */
     public function isRunning(int $pid): bool
     {
-        if (!array_key_exists($pid, $this->threads)) {
+        if (!\array_key_exists($pid, $this->threads)) {
             return false;
         }
 
@@ -114,6 +114,6 @@ class Fork implements ForkInterface
      */
     public function getPIDs(): array
     {
-        return array_values($this->threads);
+        return \array_values($this->threads);
     }
 }

--- a/src/SharedMemory.php
+++ b/src/SharedMemory.php
@@ -24,14 +24,14 @@ final class SharedMemory
     public function __construct()
     {
         # Avoid creating 2 instances using the same memory segment
-        usleep(1000);
+        \usleep(1000);
 
-        $this->key = (int) (microtime(true) * 1000);
+        $this->key = (int) (\microtime(true) * 1000);
 
         # Initialise the memory
         $memory = $this->getMemory();
-        shmop_write($memory, serialize([]), 0);
-        shmop_close($memory);
+        \shmop_write($memory, \serialize([]), 0);
+        \shmop_close($memory);
     }
 
 
@@ -42,7 +42,7 @@ final class SharedMemory
      */
     private function getMemory()
     {
-        $memory = shmop_open($this->key, "c", 0644, self::LIMIT);
+        $memory = \shmop_open($this->key, "c", 0644, self::LIMIT);
 
         if (!$memory) {
             throw new Exception("Unable to open the shared memory block");
@@ -61,11 +61,11 @@ final class SharedMemory
      */
     private function unserialize($memory): array
     {
-        $data = shmop_read($memory, 0, self::LIMIT);
+        $data = \shmop_read($memory, 0, self::LIMIT);
 
-        $exceptions = unserialize($data);
+        $exceptions = \unserialize($data);
 
-        if (!is_array($exceptions)) {
+        if (!\is_array($exceptions)) {
             $exceptions = [];
         }
 
@@ -86,12 +86,12 @@ final class SharedMemory
 
         $exceptions = $this->unserialize($memory);
 
-        $exceptions[] = get_class($exception) . ": " . $exception->getMessage() . " (" . $exception->getFile() . ":" . $exception->getLine() . ")";
+        $exceptions[] = \get_class($exception) . ": " . $exception->getMessage() . " (" . $exception->getFile() . ":" . $exception->getLine() . ")";
 
-        $data = serialize($exceptions);
+        $data = \serialize($exceptions);
 
-        shmop_write($memory, $data, 0);
-        shmop_close($memory);
+        \shmop_write($memory, $data, 0);
+        \shmop_close($memory);
     }
 
 
@@ -106,9 +106,9 @@ final class SharedMemory
 
         $exceptions = $this->unserialize($memory);
 
-        shmop_write($memory, serialize([]), 0);
+        \shmop_write($memory, \serialize([]), 0);
 
-        shmop_close($memory);
+        \shmop_close($memory);
 
         return $exceptions;
     }
@@ -121,10 +121,10 @@ final class SharedMemory
      */
     public function delete()
     {
-        $memory = shmop_open($this->key, "a", 0, 0);
+        $memory = \shmop_open($this->key, "a", 0, 0);
         if ($memory) {
-            shmop_delete($memory);
-            shmop_close($memory);
+            \shmop_delete($memory);
+            \shmop_close($memory);
         }
     }
 }

--- a/src/Threads.php
+++ b/src/Threads.php
@@ -39,7 +39,7 @@ final class Threads implements ForkInterface
      */
     public function call(callable $func, ...$args): int
     {
-        if (count($this->getPIDs()) >= $this->limit) {
+        if (\count($this->getPIDs()) >= $this->limit) {
             $this->waitForAnyThread();
         }
 
@@ -92,7 +92,7 @@ final class Threads implements ForkInterface
             }
 
             # If none of the threads have finished let, wait for a second before checking again
-            sleep(1);
+            \sleep(1);
         }
     }
 }

--- a/tests/ForkTest.php
+++ b/tests/ForkTest.php
@@ -38,7 +38,7 @@ class ForkTest extends TestCase
             public function call(callable $func, ...$args): int
             {
                 $func(...$args);
-                return rand(1, 999);
+                return \rand(1, 999);
             }
             public function isRunning(int $pid): bool
             {
@@ -92,14 +92,14 @@ class ForkTest extends TestCase
     {
         $this->getSimpleAdapter();
 
-        $tmp = tempnam(sys_get_temp_dir(), "phpunit-fork-helper-");
-        $this->assertTrue(is_string($tmp));
+        $tmp = \tempnam(\sys_get_temp_dir(), "phpunit-fork-helper-");
+        $this->assertTrue(\is_string($tmp));
 
         $this->fork->call(function ($tmp) {
-            file_put_contents($tmp, "success!");
+            \file_put_contents($tmp, "success!");
         }, $tmp);
 
-        $this->assertSame("success!", file_get_contents($tmp));
+        $this->assertSame("success!", \file_get_contents($tmp));
     }
 
 
@@ -169,7 +169,7 @@ class ForkTest extends TestCase
         $pids[] = $this->fork->call("phpversion");
         $pids[] = $this->fork->call("phpversion");
 
-        $pid = array_shift($pids);
+        $pid = \array_shift($pids);
 
         $result = $this->fork->wait($pid);
         $this->assertSame($this->fork, $result);
@@ -202,19 +202,19 @@ class ForkTest extends TestCase
         $duration = 10 ** 5;
 
         $sleep = function () use ($duration) {
-            usleep($duration);
+            \usleep($duration);
         };
 
 
         $sut = new Fork(new PcntlAdapter());
-        $time = microtime(true);
+        $time = \microtime(true);
 
         $pid = $sut->call($sleep);
         $sut->wait($pid);
 
         $pid = $sut->call($sleep);
         $sut->wait($pid);
-        $actualDuration = microtime(true) - $time;
+        $actualDuration = \microtime(true) - $time;
         $expectedDuration = 2 * $duration / 10 ** 6;
         $this->assertTrue(
             $actualDuration > $expectedDuration,
@@ -227,19 +227,19 @@ class ForkTest extends TestCase
         $duration = 10 ** 5;
 
         $sleep = function () use ($duration) {
-            usleep($duration);
+            \usleep($duration);
         };
 
 
         $sut = new Fork(new PcntlAdapter());
-        $time = microtime(true);
+        $time = \microtime(true);
 
-        foreach (range(0, 5) as $item) {
+        foreach (\range(0, 5) as $item) {
             $sut->call($sleep);
         }
         $sut->wait();
 
-        $actualDuration = microtime(true) - $time;
+        $actualDuration = \microtime(true) - $time;
 
         $expectedDuration = $duration / 10 ** 6;
         $this->assertTrue(
@@ -260,7 +260,7 @@ class ForkTest extends TestCase
         };
         $sut = new Fork(new PcntlAdapter());
 
-        foreach (range(0, 5) as $item) {
+        foreach (\range(0, 5) as $item) {
             $sut->call($throw, "Exception $item", $item);
         }
 
@@ -268,7 +268,7 @@ class ForkTest extends TestCase
             $sut->wait();
             $this->fail("Exception should be thrown on errors in child processes");
         } catch (Exception $e) {
-            $this->assertCount(8, explode("\n", $e->getMessage()));
+            $this->assertCount(8, \explode("\n", $e->getMessage()));
         }
     }
 }

--- a/tests/PcntlAdapterTest.php
+++ b/tests/PcntlAdapterTest.php
@@ -24,45 +24,45 @@ class PcntlAdapterTest extends TestCase
     public function testOutput()
     {
         $output = "";
-        $memoryKey = ftok(__FILE__, "t");
+        $memoryKey = \ftok(__FILE__, "t");
         $memoryLimit = 100;
 
         $writeToMemory = function ($string) use (&$output, $memoryKey, $memoryLimit) {
-            $memory = shmop_open($memoryKey, "c", 0644, $memoryLimit);
-            assert(is_resource($memory));
-            $output = shmop_read($memory, 0, $memoryLimit);
-            if ($output = trim($output)) {
+            $memory = \shmop_open($memoryKey, "c", 0644, $memoryLimit);
+            \assert(\is_resource($memory));
+            $output = \shmop_read($memory, 0, $memoryLimit);
+            if ($output = \trim($output)) {
                 $output .= "\n";
             }
             $output .= $string;
-            shmop_write($memory, $output, 0);
-            shmop_close($memory);
+            \shmop_write($memory, $output, 0);
+            \shmop_close($memory);
         };
 
         $this->fork->call(function () use ($writeToMemory) {
             $writeToMemory("func1.1");
-            usleep(80000);
+            \usleep(80000);
             $writeToMemory("func1.2");
         });
 
         $this->fork->call(function () use ($writeToMemory) {
-            usleep(50000);
+            \usleep(50000);
             $writeToMemory("func2.1");
-            usleep(50000);
+            \usleep(50000);
             $writeToMemory("func2.2");
         });
 
-        usleep(75000);
+        \usleep(75000);
         $writeToMemory("waiting");
 
         $this->fork->wait();
         $writeToMemory("end");
 
-        $memory = shmop_open($memoryKey, "a", 0, 0);
-        assert(is_resource($memory));
-        $output = trim(shmop_read($memory, 0, $memoryLimit));
-        shmop_delete($memory);
-        shmop_close($memory);
+        $memory = \shmop_open($memoryKey, "a", 0, 0);
+        \assert(\is_resource($memory));
+        $output = \trim(\shmop_read($memory, 0, $memoryLimit));
+        \shmop_delete($memory);
+        \shmop_close($memory);
 
         $this->assertSame("func1.1\nfunc2.1\nwaiting\nfunc1.2\nfunc2.2\nend", $output);
     }
@@ -104,7 +104,7 @@ class PcntlAdapterTest extends TestCase
     {
         $pid = $this->fork->call("usleep", 100);
 
-        usleep(100000);
+        \usleep(100000);
         $this->assertFalse($this->fork->isRunning($pid));
         $this->assertSame([], $this->fork->getPIDs());
 

--- a/tests/SharedMemoryTest.php
+++ b/tests/SharedMemoryTest.php
@@ -13,7 +13,7 @@ class SharedMemoryTest extends TestCase
 
     public function setUp()
     {
-        error_reporting(\E_ALL);
+        \error_reporting(\E_ALL);
 
         $memory = new SharedMemory();
         $this->memory = new Intruder($memory);
@@ -32,7 +32,7 @@ class SharedMemoryTest extends TestCase
     public function testConstructor()
     {
         # Avoid warning/notices
-        error_reporting(0);
+        \error_reporting(0);
 
         # Ensure that two instances are not given the same key
         $memory1 = new SharedMemory();
@@ -60,7 +60,7 @@ class SharedMemoryTest extends TestCase
 
         $exceptions = $this->memory->getExceptions();
 
-        $this->assertSame(1, count($exceptions));
+        $this->assertSame(1, \count($exceptions));
 
         $this->assertStringMatchesFormat("RuntimeException: Whoops (%s:%i)", $exceptions[0]);
     }
@@ -73,7 +73,7 @@ class SharedMemoryTest extends TestCase
 
         $exceptions = $this->memory->getExceptions();
 
-        $this->assertSame(2, count($exceptions));
+        $this->assertSame(2, \count($exceptions));
 
         $this->assertStringMatchesFormat("RuntimeException: Whoops (%s:%i)", $exceptions[0]);
         $this->assertStringMatchesFormat("DomainException: Nope (%s:%s)", $exceptions[1]);
@@ -84,15 +84,15 @@ class SharedMemoryTest extends TestCase
     {
         $this->memory->addException(new \RuntimeException("Whoops"));
         $exceptions = $this->memory->getExceptions();
-        $this->assertSame(1, count($exceptions));
+        $this->assertSame(1, \count($exceptions));
         $this->assertStringMatchesFormat("RuntimeException: Whoops (%s:%i)", $exceptions[0]);
 
         $exceptions = $this->memory->getExceptions();
-        $this->assertSame(0, count($exceptions));
+        $this->assertSame(0, \count($exceptions));
 
         $this->memory->addException(new \DomainException("Nope"));
         $exceptions = $this->memory->getExceptions();
-        $this->assertSame(1, count($exceptions));
+        $this->assertSame(1, \count($exceptions));
         $this->assertStringMatchesFormat("DomainException: Nope (%s:%s)", $exceptions[0]);
     }
 
@@ -107,6 +107,6 @@ class SharedMemoryTest extends TestCase
         # Make sure the memory has been cleaned up by attempting to access it
         $this->expectException(Error::class);
         $this->expectExceptionMessage("shmop_open(): unable to attach or create shared memory segment 'No such file or directory'");
-        shmop_open($key, "a", 0, 0);
+        \shmop_open($key, "a", 0, 0);
     }
 }

--- a/tests/SingleThreadAdapterTest.php
+++ b/tests/SingleThreadAdapterTest.php
@@ -79,7 +79,7 @@ class SingleThreadAdapterTest extends TestCase
         $this->assertSame(256, $status);
 
         $exceptions = $this->adapter->getExceptions();
-        $this->assertSame(1, count($exceptions));
+        $this->assertSame(1, \count($exceptions));
         $this->assertInstanceOf(\RuntimeException::class, $exceptions[0]);
         $this->assertSame("Test", $exceptions[0]->getMessage());
     }
@@ -107,7 +107,7 @@ class SingleThreadAdapterTest extends TestCase
         $this->assertSame(256, $status);
 
         $exceptions = $this->adapter->getExceptions();
-        $this->assertSame(2, count($exceptions));
+        $this->assertSame(2, \count($exceptions));
         $this->assertInstanceOf(\InvalidArgumentException::class, $exceptions[0]);
         $this->assertSame("Nope", $exceptions[0]->getMessage());
         $this->assertInstanceOf(\DomainException::class, $exceptions[1]);


### PR DESCRIPTION
Reproduce with:
php php-cs-fixer --rules=native_function_invocation fix ./ --allow-risky=yes
(php-cs-fixer from : https://cs.symfony.com/)

Details:
https://veewee.github.io/blog/optimizing-php-performance-by-fq-function-calls/