### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/ForkTest.php
+++ b/tests/ForkTest.php
@@ -19,7 +19,7 @@ class ForkTest extends TestCase
     private $fork;
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/PcntlAdapterTest.php
+++ b/tests/PcntlAdapterTest.php
@@ -16,7 +16,7 @@ class PcntlAdapterTest extends TestCase
     /** @var ForkInterface */
     private $fork;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->fork = new Fork(new PcntlAdapter());
     }

--- a/tests/SharedMemoryTest.php
+++ b/tests/SharedMemoryTest.php
@@ -11,7 +11,7 @@ class SharedMemoryTest extends TestCase
 {
     private $memory;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         error_reporting(\E_ALL);
 
@@ -20,7 +20,7 @@ class SharedMemoryTest extends TestCase
     }
 
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         try {
             $this->memory->delete();

--- a/tests/SingleThreadAdapterTest.php
+++ b/tests/SingleThreadAdapterTest.php
@@ -18,7 +18,7 @@ class SingleThreadAdapterTest extends TestCase
     private $fork;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->adapter = new SingleThreadAdapter();
         $this->fork = new Fork($this->adapter);

--- a/tests/ThreadsTest.php
+++ b/tests/ThreadsTest.php
@@ -17,7 +17,7 @@ class ThreadsTest extends TestCase
     private $fork;
 
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->fork = Mockery::mock(ForkInterface::class);
         $this->threads = new Threads(3, $this->fork);


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp` and `protected function tearDown` methods.